### PR TITLE
Update def sentiment_analysis spark-streaming.py

### DIFF
--- a/src/jobs/spark-streaming.py
+++ b/src/jobs/spark-streaming.py
@@ -9,23 +9,16 @@ from config.config import config
 
 def sentiment_analysis(comment) -> str:
     if comment:
-        openai.api_key = config['openai']['api_key']
-        completion = openai.ChatCompletion.create(
+        import openai
+        client = openai.OpenAI(api_key=config['openai']['api_key'])
+        response = client.chat.completions.create(
             model='gpt-3.5-turbo',
-            messages = [
-                {
-                    "role": "system",
-                    "content": """
-                        You're a machine learning model with a task of classifying comments into POSITIVE, NEGATIVE, NEUTRAL.
-                        You are to respond with one word from the option specified above, do not add anything else.
-                        Here is the comment:
-                        
-                        {comment}
-                    """.format(comment=comment)
-                }
+            messages=[
+                {"role": "system", "content": "You are a machine learning model tasked with classifying comments as POSITIVE, NEGATIVE, or NEUTRAL. You should respond with only one of these words, adding nothing else."},
+                {"role": "user", "content": comment}
             ]
         )
-        return completion.choices[0].message['content']
+        return response.choices[0].message.content.strip()
     return "Empty"
 
 def start_streaming(spark):


### PR DESCRIPTION
(import openai could be moved to the begining of the code in this file)
This change proposed helps to avoid:
_Caused by: org.apache.spark.api.python.PythonException: Traceback (most recent call last):
  File "/opt/bitnami/spark/jobs/spark-streaming.py", line 14, in sentiment_analysis
    completion = openai.ChatCompletion.create(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/bitnami/python/lib/python3.11/site-packages/openai/lib/_old_api.py", line 39, in __call__
    raise APIRemovedInV1(symbol=self._symbol)
openai.lib._old_api.APIRemovedInV1:

You tried to access openai.ChatCompletion, but this is no longer supported in openai>=1.0.0 - see the README at https://github.com/openai/openai-python for the API._